### PR TITLE
Allow access to the remoteStorage server on port 443

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@ Get the content of this repository (or clone it), run Vagrant
     $ cd php-remote-storage-deployment-master
     $ vagrant up
 
-By default `vagrant up` will use the virtualbox provider. 
+By default `vagrant up` will use the Virtualbox provider.
+
+If your host support Avahi/ZeroConf (by default OS X uses it) the
+remoteStorage server will be available under https://storage.local. For now
+you need to accept the self-signed certificate. You can then log in with a
+remoteStorage app using `foo@storage.local` and `bar` as a password.
+
+If you're not using Avahi/ZeroConf you can add an entry to `/etc/hosts`:
+
+    $ echo "192.168.33.10\tstorage.local" | sudo tee -a /etc/hosts
 
 ## Vagrant On Fedora
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,12 +22,12 @@ Vagrant.configure(2) do |config|
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 80,  host: 8480
-  config.vm.network "forwarded_port", guest: 443, host: 8443
+  # config.vm.network "forwarded_port", guest: 80,  host: 8480
+  # config.vm.network "forwarded_port", guest: 443, host: 8443
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "192.168.33.10"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -58,4 +58,5 @@ Vagrant.configure(2) do |config|
   config.vm.provision "file", source: "storage.example-httpd.conf",
                               destination: "/home/vagrant/storage.example-httpd.conf"
   config.vm.provision "shell", path: "deploy.sh"
+  config.vm.provision "shell", inline: "dnf install avahi -y; systemctl start avahi-daemon.service"
 end


### PR DESCRIPTION
This is done using Avahi/ZeroConf (no user intervention required) or by
manually adding an entry to `/etc/hosts`